### PR TITLE
added the str() type cast to the row to fix the following error:

### DIFF
--- a/export_saved.py
+++ b/export_saved.py
@@ -252,7 +252,7 @@ def write_csv(csv_rows, file_name=None):
                 try:
                     csvwriter.writerow(row)
                 except UnicodeEncodeError:
-                    csvwriter.writerow(row.encode('utf-8', 'ignore'))
+                    csvwriter.writerow(str(row).encode('utf-8', 'ignore'))
 
 
 def process(reddit, seq, file_name, folder_name):


### PR DESCRIPTION
Traceback (most recent call last):
  File ".\export_saved.py", line 244, in write_csv
    csvwriter.writerow(csv_fields)
TypeError: a bytes-like object is required, not 'str'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".\export_saved.py", line 253, in write_csv
    csvwriter.writerow(row)
  File "H:\Programs\Python\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f61c' in position 168: character maps to <undefined>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File ".\export_saved.py", line 329, in <module>
    main()
  File ".\export_saved.py", line 323, in main
    save_saved(reddit)
  File ".\export_saved.py", line 287, in save_saved
    process(reddit, seq, "export-saved", "Reddit - Saved")
  File ".\export_saved.py", line 269, in process
    write_csv(csv_rows, file_name + ".csv")
  File ".\export_saved.py", line 255, in write_csv
    csvwriter.writerow(row.encode('utf-8', 'ignore'))
AttributeError: 'list' object has no attribute 'encode'