### PR TITLE
quick n dirty script to backup contents of saved posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ To install without git, [download the source code from GitHub](https://github.co
       -all, --all           get upvoted, saved, comments and submissions
       -V, --version         get program version.
 
+## get-post-contents
+I included a quick-and-dirty shell script that will pull a JSON backup of all your saved posts, and create a new HTML file that includes a link to the JSON backup. it isn't pretty and uses a browser user-agent, as well as going one-by-one, so be prepared to let it sit for a while
+
 ## Updating
 To update the script to the latest version, enter the `export-saved-reddit` folder in your shell/command prompt and enter the following:
 

--- a/get_post_contents.sh
+++ b/get_post_contents.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+> export-with-contents.html
+mkdir -p saved-post-data
+htmlfile=export-saved.html
+exec 4<${htmlfile} #open file descriptor to htmlfile (might be too big to read into memory)
+while read -u4 line ;
+do
+    echo "${line}" >> export-with-contents.html
+    if  [[ ${line} == *"HREF"* ]] ;
+    then
+	
+	url=$(awk -F '"' '{print $2;}' <(echo "${line}"))
+	post_tag=$(echo "${url}" | sed 's/https:\/\/www.reddit.com//' | sed 's/\///g')
+	echo "getting post data for ${url} (writing data to saved-post-data/${post_tag})"
+	data=$(curl --silent -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.89 Safari/537.36" ${url}".json")
+	echo "${data}" > saved-post-data/${post_tag}
+	echo "<a HREF=\"saved-post-data/${post_tag}\">    (link to json backup of post)</a>" >> export-with-contents.html
+    fi
+done


### PR DESCRIPTION
i made a short, ugly bash script that will create a new HTML file based on the contents of export_saved.html. it parses out links to saved posts, gets the post data in JSON format, writes the data to a local directory, then adds an HREF to the JSON data after the HREF to the actual reddit URL. It probably isn't the best way to do this since it should probably happen inside the actual python script itself (not to mention putting the backed up data inside the main HTML file instead of a directory), but it does the job. a trivial edit that might help make the backup more comprehensive would be to change the cURL request for the JSON data in to a recursive wget with a depth of 1 - this ought to get any images/other files the post may contain, but also might blow up the file size. it would be pretty easy to do tho